### PR TITLE
No need for unittest2

### DIFF
--- a/plone/event/tests/test_adapters.py
+++ b/plone/event/tests/test_adapters.py
@@ -1,8 +1,8 @@
-import unittest2 as unittest
 from zope.configuration import xmlconfig
 from plone.event.interfaces import IEvent, IEventAccessor
 from datetime import datetime
 import pytz
+import unittest
 import zope.interface
 
 

--- a/plone/event/tests/test_recurrence_int_sequence.py
+++ b/plone/event/tests/test_recurrence_int_sequence.py
@@ -1,5 +1,5 @@
 import mock
-import unittest2 as unittest
+import unittest
 
 
 class TestRecurrenceIntSequence(unittest.TestCase):

--- a/plone/event/tests/test_recurrence_sequence_ical.py
+++ b/plone/event/tests/test_recurrence_sequence_ical.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 
 
 class TestRecurrenceSequenceIcal(unittest.TestCase):

--- a/plone/event/tests/test_recurrence_sequence_timedelta.py
+++ b/plone/event/tests/test_recurrence_sequence_timedelta.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 
 
 class TestRecurrenceSequenceTimedelta(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'test': [
             'DateTime',
             'mock',
-            'unittest2',
             'zope.configuration',
         ],
     },


### PR DESCRIPTION
Since python 2.7 unittest2 was already merged with unittest.