### PR TITLE
Unify Python versions in setup.py, tox and Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
-sudo: false
 python:
     - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
+    - 3.6
+    - 3.7
+    - 3.8
 install:
     - pip install tox-travis
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py33,py34,py35
+    py27,py36,py37,py38
 
 [testenv]
 deps =


### PR DESCRIPTION
Removed testing for 3.3-3.5 from Travis and tox, added 3.6-3.8.

No code change, so no news snippet.
And no Jenkins jobs needed.