### PR TITLE
ignore dtstart and until time in rrule

### DIFF
--- a/news/23.bugfix
+++ b/news/23.bugfix
@@ -1,0 +1,1 @@
+ignore dtstart and until time in rrule in recurrence_sequence_ical [mamico]

--- a/news/23.bugfix
+++ b/news/23.bugfix
@@ -1,1 +1,1 @@
-ignore dtstart and until time in rrule in recurrence_sequence_ical [mamico]
+Ignore dtstart and until time in rrule in recurrence_sequence_ical [mamico]

--- a/plone/event/recurrence.py
+++ b/plone/event/recurrence.py
@@ -72,6 +72,11 @@ def recurrence_sequence_ical(
         duration = datetime.timedelta(0)
 
     if recrule:
+        # We want the recurrence be calculated ignoring the DTSTART, 
+        # which is defined by the event's own start.
+        #‌ Also set the UNTIL time to the end of the day to include the last
+        # occurrence for sure.
+        #
         # start is a mandatory parameter for this function, remove DTSTART
         # from recrule
         recrule = re.sub(r"DTSTART:[^;\n]*[;\n]", "", recrule, re.MULTILINE)

--- a/plone/event/recurrence.py
+++ b/plone/event/recurrence.py
@@ -72,9 +72,9 @@ def recurrence_sequence_ical(
         duration = datetime.timedelta(0)
 
     if recrule:
-        # We want the recurrence be calculated ignoring the DTSTART, 
+        # We want the recurrence be calculated ignoring the DTSTART,
         # which is defined by the event's own start.
-        #‌ Also set the UNTIL time to the end of the day to include the last
+        # ‌ Also set the UNTIL time to the end of the day to include the last
         # occurrence for sure.
         #
         # start is a mandatory parameter for this function, remove DTSTART

--- a/plone/event/recurrence.py
+++ b/plone/event/recurrence.py
@@ -72,6 +72,9 @@ def recurrence_sequence_ical(
         duration = datetime.timedelta(0)
 
     if recrule:
+        # start is a mandatory parameter for this function, remove DTSTART
+        # from recrule
+        recrule = re.sub(r"DTSTART:[^;\n]*[;\n]", "", recrule, re.MULTILINE)
         # TODO BUGFIX WRONG TIME DEFINITIONS
         # THIS HACK ensures, that UNTIL, RDATE and EXDATE definitions with
         # incorrect time (currently always set to 0:00 by the recurrence
@@ -93,9 +96,9 @@ def recurrence_sequence_ical(
         # subbing if the start time is already 000000.
         if t0str != "T000000":
             recrule = re.sub(r"T000000", t0str, recrule)
-        # Then, replace incorrect until times with the end of the day
+        # Then, replace each until times with the end of the day
         recrule = re.sub(
-            r"(UNTIL[^T]*[0-9]{8})T(000000)",
+            r"(UNTIL[^T]*[0-9]{8})T([0-9]{6}Z?)",
             r"\1T235959",
             recrule,
         )

--- a/plone/event/tests/test_recurrence_sequence_ical.py
+++ b/plone/event/tests/test_recurrence_sequence_ical.py
@@ -184,6 +184,7 @@ RDATE:20111129T000000"""
     def test_recrule_with_dtstart(self):
         from datetime import datetime
         from plone.event.recurrence import recurrence_sequence_ical
+
         import pytz
 
         at = pytz.timezone("Europe/Vienna")

--- a/plone/event/tests/test_recurrence_sequence_ical.py
+++ b/plone/event/tests/test_recurrence_sequence_ical.py
@@ -180,3 +180,17 @@ RDATE:20111129T000000"""
         recrule = "RRULE:FREQ=DAILY;UNTIL=20111130T000000Z"
         seq = list(recurrence_sequence_ical(start, recrule=recrule))
         self.assertEqual(len(seq), 7)
+
+    def test_recrule_with_dtstart(self):
+        from datetime import datetime
+        from plone.event.recurrence import recurrence_sequence_ical
+        import pytz
+
+        at = pytz.timezone("Europe/Vienna")
+        start = at.localize(datetime(2023, 9, 4, 1, 0))
+        # DTSTART is ignored, because start is ever explicitly given
+        recrule = "DTSTART:20230903T180000Z\nRRULE:FREQ=DAILY;UNTIL=20230905T230000Z"
+        seq = list(recurrence_sequence_ical(start, recrule=recrule))
+        self.assertEqual(len(seq), 2)
+        self.assertEqual(seq[0], at.localize(datetime(2023, 9, 4, 1, 0)))
+        self.assertEqual(seq[1], at.localize(datetime(2023, 9, 5, 1, 0)))


### PR DESCRIPTION
In `recurrence_sequence_ical`, the `DTSTART` in the `recrule` is used for all occurrences that follow the first one. This is a design issue because the start time is a mandatory parameter, and its time must be used for every occurrence, by design.

For the same reason, the time in the UNTIL field must always be ignored.

Problems occur, for example, with the `rrule` widget in Volto (see also https://github.com/plone/volto/pull/5002), which consistently returns a DTSTART and UNTIL field inside the recrule with a timezone (UTC).