### PR TITLE
fix exdate

### DIFF
--- a/news/30-2.bugfix
+++ b/news/30-2.bugfix
@@ -1,0 +1,2 @@
+Keep the rrule UNTIL property UTC specifier, if defined.
+[mamico]

--- a/news/30.bugfix
+++ b/news/30.bugfix
@@ -1,0 +1,4 @@
+Set the rrule's EXDATE to the same time as the event's start time.
+In our implementation we want the rrule's EXDATE property to have the same time as the event's start time.
+Otherwise recurrence dates might be included where they should not due to an user-undefined EXDATE time.
+[mamico]

--- a/plone/event/recurrence.py
+++ b/plone/event/recurrence.py
@@ -103,8 +103,8 @@ def recurrence_sequence_ical(
             recrule = re.sub(r"T000000", t0str, recrule)
         # Then, replace each until times with the end of the day
         recrule = re.sub(
-            r"(UNTIL[^T]*[0-9]{8})T([0-9]{6}Z?)",
-            r"\1T235959",
+            r"(UNTIL[^T]*[0-9]{8})T([0-9]{6})(Z?)",
+            r"\1T235959\3",
             recrule,
         )
 

--- a/plone/event/recurrence.py
+++ b/plone/event/recurrence.py
@@ -72,49 +72,38 @@ def recurrence_sequence_ical(
         duration = datetime.timedelta(0)
 
     if recrule:
-        # We want the recurrence be calculated ignoring the DTSTART,
-        # which is defined by the event's own start.
-        # ‌ Also set the UNTIL time to the end of the day to include the last
-        # occurrence for sure.
-        #
-        # start is a mandatory parameter for this function, remove DTSTART
-        # from recrule
-        recrule = re.sub(r"DTSTART:[^;\n]*[;\n]", "", recrule, re.MULTILINE)
-        # TODO BUGFIX WRONG TIME DEFINITIONS
-        # THIS HACK ensures, that UNTIL, RDATE and EXDATE definitions with
-        # incorrect time (currently always set to 0:00 by the recurrence
-        # widget) are handled correctly.
-        #
-        # Following fixes are made:
-        # - The UNTIL date should be included in the recurrence set, as defined
-        #   by RFC5545 (fix sets it to the end of the day)
-        # - RDATE definitions should have the same time as the start date.
-        # - EXDATE definitions should exclude occurrences on the specific date
-        #   only the same time as the start date.
-        # In the long term ,the recurrence widget should be able to set the
-        # time for UNTIL, RDATE and EXDATE.
-        t0 = start.time()  # set initial time information.
-        # First, replace all times in the recurring rule with starttime
+        # The event's start time.
+        t0 = start.time()
+        # The event's start time as RFC8601 string
         t0str = f"T{t0.hour:02d}{t0.minute:02d}{t0.second:02d}"
-        # Replace any times set to 000000 with start time, not all
-        # rrules are set by a specific broken widget.  Don't waste time
-        # subbing if the start time is already 000000.
+
+        # 1) Remove DTSTART from the recurrence rule
+        # The start date is always included and therefore removed from the
+        # recurrence rule.
+        recrule = re.sub(r"DTSTART:[^;\n]*[;\n]", "", recrule, re.MULTILINE)
+
+        # 2) Set all RDATE (actually any) time definitions to the start date of
+        # the event, except for those explicitly set to 00:00:00 which might
+        # come from recurrence rule widgets which explicitly set it to that
+        # time.
         if t0str != "T000000":
             recrule = re.sub(r"T000000", t0str, recrule)
-        # Then, replace each until times with the end of the day
+
+        # 3) Set the UNTIL times to the end of the day to make sure to include
+        # any possible occurrence on that date.
         recrule = re.sub(
             r"(UNTIL[^T]*[0-9]{8})T([0-9]{6})(Z?)",
             r"\1T235959\3",
             recrule,
         )
 
-        # The time of EXDATE, according to previous comments, should be the
-        # same as the start time.
+        # 4) Set the EXDATE properties to the same start time as the event's
+        # start time to make sure to really exclude those occurrences.
         recrule = re.sub(
             r"EXDATE:([^\n\s]+)",
             lambda m: re.sub(
                 r"T[0-9]{6}(Z?)",
-                rf"T{start.hour:02}{start.minute:02}{start.second:02}\1",
+                rf"{t0str}\1",
                 m.group(0),
             ),
             recrule,

--- a/plone/event/recurrence.py
+++ b/plone/event/recurrence.py
@@ -108,6 +108,18 @@ def recurrence_sequence_ical(
             recrule,
         )
 
+        # The time of EXDATE, according to previous comments, should be the
+        # same as the start time.
+        recrule = re.sub(
+            r"EXDATE:([^\n\s]+)",
+            lambda m: re.sub(
+                r"T[0-9]{6}(Z?)",
+                rf"T{start.hour:02}{start.minute:02}{start.second:02}\1",
+                m.group(0),
+            ),
+            recrule,
+        )
+
         # RFC2445 string
         # forceset: always return a rruleset
         # dtstart: optional used when no dtstart is in RFC2445 string

--- a/plone/event/tests/test_recurrence_sequence_ical.py
+++ b/plone/event/tests/test_recurrence_sequence_ical.py
@@ -195,3 +195,25 @@ RDATE:20111129T000000"""
         self.assertEqual(len(seq), 2)
         self.assertEqual(seq[0], at.localize(datetime(2023, 9, 4, 1, 0)))
         self.assertEqual(seq[1], at.localize(datetime(2023, 9, 5, 1, 0)))
+
+    def test_recrule_with_exclude(self):
+        from datetime import datetime
+        from plone.event.recurrence import recurrence_sequence_ical
+
+        import pytz
+
+        at = pytz.timezone("UTC")
+        recrule = (
+            "RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20240428T100000Z\n"
+            "EXDATE:20240423T100000Z,20240425T100000Z"
+        )
+
+        # EXDATE with same time as start date should be excluded
+        start = at.localize(datetime(2024, 4, 22, 10, 0))
+        seq = list(recurrence_sequence_ical(start, recrule=recrule))
+        self.assertEqual(len(seq), 5)
+
+        # even EXDATE with different time as start date should be excluded
+        start = at.localize(datetime(2024, 4, 22, 14, 0))
+        seq = list(recurrence_sequence_ical(start, recrule=recrule))
+        self.assertEqual(len(seq), 5)


### PR DESCRIPTION
The time of EXDATE in rrule, should be the same as the start time

Tested on plone.demo.org

1. created an event from April 1 (10AM) to April 28 (10AM)
2. added daily recurrences
3. removed from recurrences the days from April 23 to 26
4. created a listing block and filtered the event with start date from 24 to 25, the event is returned

expected behavior

Event should not appear with previous filtering